### PR TITLE
Fix invalid packet slicing 

### DIFF
--- a/src/lib/messenger.ts
+++ b/src/lib/messenger.ts
@@ -66,7 +66,7 @@ class Messenger extends EventEmitter {
       offset = HEADER_SIZE + 4;
     }
 
-    let payload = packet.slice(offset, offset + payloadSize - 8);
+    let payload = packet.slice(offset, HEADER_SIZE + payloadSize - 8);
 
     // Check CRC
     const expectedCrc = packet.readInt32BE(HEADER_SIZE + payloadSize - 8);


### PR DESCRIPTION
As mentioned in #34 change done in commit 22d63a7c768e78ef446d3f19b0f7c0c98dfe642d broke most of the communication.